### PR TITLE
update UI and text sizing changes

### DIFF
--- a/.notion-cache/blocks-index.json
+++ b/.notion-cache/blocks-index.json
@@ -10,7 +10,7 @@
     "parentId": "684ab557-5424-4cbc-aa55-543d4c9190b7"
   },
   "183b7ed0-f532-80ab-ae70-c335de0d2974": {
-    "cachedAt": 1765631232605,
+    "cachedAt": 1767276531336,
     "size": 71710,
     "parentId": "183b7ed0-f532-80ab-ae70-c335de0d2974"
   },
@@ -25,27 +25,27 @@
     "parentId": "8cc9fea6-ebfc-4d0e-95c8-5d155e6741b7"
   },
   "16eb7ed0-f532-80a1-892e-c1f461e9f48a": {
-    "cachedAt": 1765631467567,
+    "cachedAt": 1767284829178,
     "size": 194887,
     "parentId": "16eb7ed0-f532-80a1-892e-c1f461e9f48a"
   },
   "16eb7ed0-f532-80b9-bf29-d97cba555162": {
-    "cachedAt": 1765631467930,
+    "cachedAt": 1767284829959,
     "size": 2380,
     "parentId": "16eb7ed0-f532-80a1-892e-c1f461e9f48a"
   },
   "16eb7ed0-f532-8067-8d24-f06f2250e82a": {
-    "cachedAt": 1765631468046,
+    "cachedAt": 1767284829923,
     "size": 17731,
     "parentId": "16eb7ed0-f532-80a1-892e-c1f461e9f48a"
   },
   "16eb7ed0-f532-8097-8900-e96214fda436": {
-    "cachedAt": 1765631468362,
+    "cachedAt": 1767284830749,
     "size": 6560,
     "parentId": "16eb7ed0-f532-80a1-892e-c1f461e9f48a"
   },
   "16eb7ed0-f532-8009-a275-ccf8602b15a8": {
-    "cachedAt": 1765631468902,
+    "cachedAt": 1767284829923,
     "size": 2292,
     "parentId": "16eb7ed0-f532-80a1-892e-c1f461e9f48a"
   },
@@ -60,7 +60,7 @@
     "parentId": "8cc9fea6-ebfc-4d0e-95c8-5d155e6741b7"
   },
   "9c832544-1b22-43aa-80c7-2bbc30d02cc7": {
-    "cachedAt": 1765634103586,
+    "cachedAt": 1767277503934,
     "size": 1960,
     "parentId": "15684931-fdbb-4d1a-8daf-afee6959c1bd"
   },
@@ -83,5 +83,25 @@
     "cachedAt": 1765634108030,
     "size": 13721,
     "parentId": "9dd2ac02-6495-4f87-81c7-b58c2888f077"
+  },
+  "15684931-fdbb-4d1a-8daf-afee6959c1bd": {
+    "cachedAt": 1767277501216,
+    "size": 66924,
+    "parentId": "15684931-fdbb-4d1a-8daf-afee6959c1bd"
+  },
+  "567ff1bd-a921-4968-896a-3e1c6eb1eaa5": {
+    "cachedAt": 1767286973071,
+    "size": 66368,
+    "parentId": "567ff1bd-a921-4968-896a-3e1c6eb1eaa5"
+  },
+  "6d05c37d-dac6-46f3-8628-d1309033c6c7": {
+    "cachedAt": 1767286990169,
+    "size": 120159,
+    "parentId": "6d05c37d-dac6-46f3-8628-d1309033c6c7"
+  },
+  "9946950b-35ed-47e2-8ab0-0e1d15bcde94": {
+    "cachedAt": 1767287130152,
+    "size": 111004,
+    "parentId": "9946950b-35ed-47e2-8ab0-0e1d15bcde94"
   }
 }

--- a/.notion-cache/index.json
+++ b/.notion-cache/index.json
@@ -1,15 +1,15 @@
 {
   "15684931-fdbb-4d1a-8daf-afee6959c1bd": {
     "lastModified": "2025-01-11T13:41:00.000Z",
-    "cachedAt": 1765630611246
+    "cachedAt": 1767277501219
   },
   "567ff1bd-a921-4968-896a-3e1c6eb1eaa5": {
     "lastModified": "2025-01-11T13:41:00.000Z",
-    "cachedAt": 1765630611814
+    "cachedAt": 1767286973074
   },
   "6d05c37d-dac6-46f3-8628-d1309033c6c7": {
     "lastModified": "2025-01-11T13:41:00.000Z",
-    "cachedAt": 1765630612390
+    "cachedAt": 1767286990172
   },
   "8cc9fea6-ebfc-4d0e-95c8-5d155e6741b7": {
     "lastModified": "2025-11-05T08:48:00.000Z",
@@ -41,7 +41,7 @@
   },
   "9946950b-35ed-47e2-8ab0-0e1d15bcde94": {
     "lastModified": "2025-01-11T13:42:00.000Z",
-    "cachedAt": 1765630617722
+    "cachedAt": 1767287130163
   },
   "afdafcd4-f03d-4809-ad8e-011d953a4daf": {
     "lastModified": "2025-01-11T13:42:00.000Z",
@@ -73,11 +73,11 @@
   },
   "183b7ed0-f532-80ab-ae70-c335de0d2974": {
     "lastModified": "2025-07-12T10:39:00.000Z",
-    "cachedAt": 1765631232608
+    "cachedAt": 1767276531338
   },
   "16eb7ed0-f532-80a1-892e-c1f461e9f48a": {
     "lastModified": "2025-07-13T06:33:00.000Z",
-    "cachedAt": 1765631467570
+    "cachedAt": 1767284829180
   },
   "c9473c58-54de-46d6-9f05-d4b51d2b6339": {
     "lastModified": "2025-01-11T13:41:00.000Z",

--- a/.notion-cache/pages/15684931-fdbb-4d1a-8daf-afee6959c1bd.json
+++ b/.notion-cache/pages/15684931-fdbb-4d1a-8daf-afee6959c1bd.json
@@ -180,7 +180,7 @@
     },
     "url": "https://www.notion.so/Tailwind-CSS-3-What-s-Fresh-15684931fdbb4d1a8dafafee6959c1bd",
     "public_url": null,
-    "request_id": "7b1cceb2-7f04-4509-8ad8-3a4052667dd6"
+    "request_id": "c0b18e34-e351-4359-a89a-84a708167b6f"
   },
   "blocks": [
     {
@@ -2518,5 +2518,5 @@
     }
   ],
   "lastModified": "2025-01-11T13:41:00.000Z",
-  "cachedAt": 1765630611245
+  "cachedAt": 1767277501217
 }

--- a/.notion-cache/pages/16eb7ed0-f532-80a1-892e-c1f461e9f48a.json
+++ b/.notion-cache/pages/16eb7ed0-f532-80a1-892e-c1f461e9f48a.json
@@ -180,7 +180,7 @@
     },
     "url": "https://www.notion.so/Deploying-ML-models-Faster-Leaner-Scalable-16eb7ed0f53280a1892ec1f461e9f48a",
     "public_url": null,
-    "request_id": "00fb9c64-31ec-4141-8bfd-5a47701d3829"
+    "request_id": "4fd50934-9ce9-4b6f-9a1f-98327e4a041e"
   },
   "blocks": [
     {
@@ -6969,5 +6969,5 @@
     }
   ],
   "lastModified": "2025-07-13T06:33:00.000Z",
-  "cachedAt": 1765631467567
+  "cachedAt": 1767284829178
 }

--- a/.notion-cache/pages/183b7ed0-f532-80ab-ae70-c335de0d2974.json
+++ b/.notion-cache/pages/183b7ed0-f532-80ab-ae70-c335de0d2974.json
@@ -177,7 +177,7 @@
     },
     "url": "https://www.notion.so/Builder-Design-Pattern-183b7ed0f53280abae70c335de0d2974",
     "public_url": null,
-    "request_id": "f76f0019-d194-49d6-962b-80fecd628103"
+    "request_id": "2da4448a-a898-40e9-9689-3cd26619b62b"
   },
   "blocks": [
     {
@@ -2493,5 +2493,5 @@
     }
   ],
   "lastModified": "2025-07-12T10:39:00.000Z",
-  "cachedAt": 1765631232606
+  "cachedAt": 1767276531337
 }

--- a/.notion-cache/pages/567ff1bd-a921-4968-896a-3e1c6eb1eaa5.json
+++ b/.notion-cache/pages/567ff1bd-a921-4968-896a-3e1c6eb1eaa5.json
@@ -177,7 +177,7 @@
     },
     "url": "https://www.notion.so/Singleton-Design-Pattern-567ff1bda9214968896a3e1c6eb1eaa5",
     "public_url": null,
-    "request_id": "5bf7b701-c447-4d52-bc33-9102c64e5f12"
+    "request_id": "887a04bd-d41b-4ebd-87a3-e8013d15fbea"
   },
   "blocks": [
     {
@@ -2562,5 +2562,5 @@
     }
   ],
   "lastModified": "2025-01-11T13:41:00.000Z",
-  "cachedAt": 1765630611813
+  "cachedAt": 1767286973071
 }

--- a/.notion-cache/pages/6d05c37d-dac6-46f3-8628-d1309033c6c7.json
+++ b/.notion-cache/pages/6d05c37d-dac6-46f3-8628-d1309033c6c7.json
@@ -180,7 +180,7 @@
     },
     "url": "https://www.notion.so/Fundamentals-of-Kafka-6d05c37ddac646f38628d1309033c6c7",
     "public_url": null,
-    "request_id": "b4415bd2-fde6-4b26-b9fa-6e2104296a44"
+    "request_id": "d2e5ef8c-5765-4491-9d11-50f5a8dbb5eb"
   },
   "blocks": [
     {
@@ -4010,5 +4010,5 @@
     }
   ],
   "lastModified": "2025-01-11T13:41:00.000Z",
-  "cachedAt": 1765630612386
+  "cachedAt": 1767286990169
 }

--- a/.notion-cache/pages/9946950b-35ed-47e2-8ab0-0e1d15bcde94.json
+++ b/.notion-cache/pages/9946950b-35ed-47e2-8ab0-0e1d15bcde94.json
@@ -180,7 +180,7 @@
     },
     "url": "https://www.notion.so/Kubernetes-Secrets-Best-Practices-9946950b35ed47e28ab00e1d15bcde94",
     "public_url": null,
-    "request_id": "a73fb9a4-bd69-42b2-9497-2a6d5d9aeb81"
+    "request_id": "37df062b-9a46-4e31-aefc-c7366eb83971"
   },
   "blocks": [
     {
@@ -4052,5 +4052,5 @@
     }
   ],
   "lastModified": "2025-01-11T13:42:00.000Z",
-  "cachedAt": 1765630617721
+  "cachedAt": 1767287130153
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,178 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A performance-optimized Next.js blog using Notion as a headless CMS with Tailwind CSS styling. The architecture emphasizes caching, lazy loading, and web vitals monitoring.
+
+## Package Manager
+
+**Always use `yarn` for all package operations** - never use npm or npx.
+
+## Essential Commands
+
+### Development
+```bash
+yarn dev              # Development server with Turbopack (default, faster)
+yarn dev:webpack      # Development with Webpack (fallback)
+yarn build            # Production build (uses Webpack)
+yarn start            # Start production server
+```
+
+### Code Quality
+```bash
+yarn lint             # Run ESLint
+```
+
+### Performance & Analysis
+```bash
+yarn analyze          # Bundle analysis (sets ANALYZE=true)
+yarn lighthouse       # Run Lighthouse CI performance audits
+```
+
+### Cache Management
+```bash
+yarn cache:stats           # Show cache statistics
+yarn cache:clear           # Clear all cache
+yarn cache:clear-expired   # Clear only expired cache entries
+yarn cache:warm            # Pre-warm cache for build optimization
+```
+
+## Architecture Overview
+
+### Notion CMS Integration
+
+**Core pattern**: Notion database → `lib/notion.ts` → Transformed blog posts
+
+**Required Notion database columns**:
+- `Page` (title): Blog post headline and meta title
+- `Slug` (text): URL slug
+- `Date` (date): Display date and published_time
+- `Description` (text): Preview text and meta description
+- `Published` (checkbox): Must be checked
+- `stage` (select): Must be "Published" for posts to appear
+- `Cover Image` (files & media): Optional cover/featured image
+
+**Environment variables** (`.env.local`):
+```bash
+NOTION_API_TOKEN=secret_xxx
+NOTION_BLOG_DATABASE_ID=xxx
+```
+
+### Multi-Layer Caching System
+
+The application implements three caching levels:
+
+1. **In-memory cache** (`lib/notion.ts`):
+   - Blog posts list cached for 5 minutes
+   - Resets on app restart
+   - Check status: `getBlogPostsCacheStatus()`
+
+2. **File-based cache** (`.notion-cache/`):
+   - Pages cache: `.notion-cache/pages/{pageId}.json`
+   - Blocks cache: `.notion-cache/blocks/{blockId}.json`
+   - TTL: 24 hours
+   - Invalidation: Based on Notion's `last_edited_time`
+
+3. **Build-time cache** (`lib/buildCache.ts`):
+   - Used during static site generation
+   - Managed by cache-manager.js script
+
+**Key caching functions**:
+- `getAllPublishedBlogPosts()`: Fetches blog list with memory caching
+- `getNotionPageWithBlocks()`: Fetches page + blocks with file caching
+- `getNotionBlockChildren()`: Fetches nested blocks with caching
+
+### Content Rendering System
+
+**Block-based architecture** (`components/ContentBlocks.tsx`):
+- `RenderBlocks()`: Main entry point for rendering Notion content
+- `RenderBlocksHelper()`: Handles individual block type mapping
+- Modular components in `components/notionblocks/`:
+  - `CommonBlocks.tsx`: Text, headings, spans
+  - `Lists.tsx`: Bulleted and numbered lists (handles nesting)
+  - `Code.tsx`: Syntax-highlighted code blocks
+  - `Image.tsx`: Optimized images
+  - `BlockQuote.tsx`, `Callout.tsx`, `Video.tsx`
+  - `Bookmark.tsx` (lazy loaded)
+  - `Table.tsx` (lazy loaded)
+
+**Performance optimization**:
+- Heavy components (Bookmark, Table) are lazy loaded with `React.lazy()`
+- Suspense boundaries with loading skeletons
+
+### Static Site Generation Pattern
+
+**Page routing** (`pages/posts/[slug].tsx`):
+- `getStaticPaths()`: Generates paths for all published posts
+- `getStaticProps()`: Fetches page + blocks at build time
+- Nested blocks are fetched recursively and attached to parent blocks
+- ISR revalidation: 6 hours in production, 1 second in development
+- Fallback: "blocking" for new posts
+
+### Type Safety with Notion API
+
+**Critical pattern**: Always check property types before accessing values
+
+```typescript
+// Correct
+title?.type === "title" ? title.title[0]?.plain_text : undefined
+
+// Incorrect - will cause runtime errors
+title.title[0].plain_text
+```
+
+Use optional chaining (`?.`) and fallbacks for all Notion API responses.
+
+## Path Aliases
+
+TypeScript path mappings (configured in `tsconfig.json`):
+```typescript
+@/components/*  → components/*
+@/data/*        → data/*
+@/layouts/*     → layouts/*
+@/lib/*         → lib/*
+@/css/*         → css/*
+@/scripts/*     → scripts/*
+```
+
+## Project-Specific Patterns
+
+### SEO & Metadata
+- Site metadata: `lib/siteMetadata.ts`
+- Page wrapper: `components/Container.tsx` (applies SEO meta tags)
+- Dynamic sitemap: `pages/sitemap.xml.tsx` (24-hour cache)
+- Dynamic robots.txt: `pages/robots.tsx`
+
+### Performance Monitoring
+- `components/PerformanceMonitor.tsx` tracks Web Vitals (CLS, INP, FCP, LCP, TTFB)
+- Uses `web-vitals` library (import from 'web-vitals', not 'next/dist/build/web-vitals')
+- Image optimization: `components/OptimizedImage.tsx` with srcSet generation
+
+### Security
+Security headers configured in `next.config.js`:
+- Content Security Policy (CSP)
+- Referrer Policy
+- X-Frame-Options
+- Strict Transport Security
+- Permissions Policy
+
+### Font Loading
+Custom fonts loaded via `lib/fonts.ts` and preloaded in `pages/_app.tsx` for optimal performance.
+
+## Key Files Reference
+
+- `lib/notion.ts`: Notion API integration and data transformation
+- `lib/notionCache.ts`: File-based caching implementation
+- `components/ContentBlocks.tsx`: Block rendering orchestration
+- `pages/posts/[slug].tsx`: Blog post page with SSG
+- `next.config.js`: Security headers, image optimization, bundle config
+- `lib/siteMetadata.ts`: Site-wide configuration and metadata
+
+## Development Notes
+
+- Console logs show "**Notion API Called**" for debugging API requests
+- Cache system prevents API rate limiting during builds
+- TypeScript strict mode is disabled (`strict: false` in tsconfig.json)
+- Production build removes console logs automatically

--- a/components/ContentBlocks.tsx
+++ b/components/ContentBlocks.tsx
@@ -41,7 +41,7 @@ function RenderBlocksHelper(blocks, index) {
   const value = blocks[index][type]
   switch (type) {
     case "divider":
-      output = <hr className="my-8 border-gray-300 dark:border-gray-600" key={id} />
+      output = <hr className="my-5 border-gray-300 dark:border-gray-600" key={id} />
       break
 
     case "paragraph":
@@ -87,11 +87,11 @@ function RenderBlocksHelper(blocks, index) {
       const caption = value.caption.length ? value.caption[0].plain_text : ""
       // render the video as iframe
       output = (
-        <figure key={id} className="my-8 w-full">
+        <figure key={id} className="my-5 w-full">
           <div className="mx-auto max-w-3xl">
             <Video url={videoSrc} />
           </div>
-          {caption && <figcaption className="mx-auto mt-4 max-w-3xl text-center text-sm leading-relaxed text-gray-600 dark:text-gray-400">{caption}</figcaption>}
+          {caption && <figcaption className="mx-auto mt-3 max-w-3xl text-center text-sm leading-normal text-gray-600 dark:text-gray-400">{caption}</figcaption>}
         </figure>
       )
       break
@@ -107,7 +107,7 @@ function RenderBlocksHelper(blocks, index) {
 
     case "bookmark":
       output = (
-        <div key={id} className="my-6 w-full">
+        <div key={id} className="my-4 w-full">
           <div className="mx-auto max-w-3xl">
             <Suspense fallback={<div className="h-40 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700"></div>}>
               <Bookmark id={id} value={value} key={index} />
@@ -123,7 +123,7 @@ function RenderBlocksHelper(blocks, index) {
 
     case "table":
       output = (
-        <div key={id} className="my-6 w-full">
+        <div key={id} className="my-4 w-full">
           <div className="mx-auto max-w-4xl">
             <Suspense fallback={<div className="h-32 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700"></div>}>
               <Table id={id} value={value} />
@@ -144,7 +144,7 @@ const ToDo = ({ id, value }) => {
     return <></>
   }
   return (
-    <div className="my-3 flex items-center space-x-3">
+    <div className="my-2 flex items-center space-x-3">
       <input type="checkbox" id={id} defaultChecked={value.checked} className="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 dark:bg-gray-700" />
       <label htmlFor={id} className="text-gray-700 dark:text-gray-300">
         <SpanText text={value.rich_text} id={id} />
@@ -155,9 +155,9 @@ const ToDo = ({ id, value }) => {
 
 const Toggle = ({ value }) => {
   return (
-    <details className="my-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-      <summary className="cursor-pointer p-4 font-medium text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{value.rich_text[0].text.content}</summary>
-      <div className="border-t border-gray-200 dark:border-gray-700 p-4">
+    <details className="my-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+      <summary className="cursor-pointer p-3 font-medium text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{value.rich_text[0].text.content}</summary>
+      <div className="border-t border-gray-200 dark:border-gray-700 p-3">
         {value.children?.map((block) => {
           if (block.type === "paragraph") {
             return <Text key={block.id} text={block.paragraph.rich_text} id={block.id} />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { siteMetadata } from "@/lib/siteMetadata"
-import { inter } from "@/lib/fonts"
+import { outfit } from "@/lib/fonts"
 
 const SocialIcon = ({ href, kind, children }) => {
   if (!href) return null
@@ -17,7 +17,7 @@ export default function Footer() {
       <div className="mx-auto max-w-3xl px-4 py-8 md:px-0 flex flex-col md:flex-row justify-between items-center gap-6">
         {/* Left: Branding & Copyright */}
         <div className="flex flex-col items-center md:items-start gap-2">
-          <div className={`text-sm font-semibold text-gray-900 dark:text-gray-100 ${inter.className}`}>{siteMetadata.author}</div>
+          <div className={`text-sm font-semibold text-gray-900 dark:text-gray-100 ${outfit.className}`}>{siteMetadata.author}</div>
           <div className="text-sm text-gray-500 dark:text-gray-400">
             © {new Date().getFullYear()} • {siteMetadata.headerTitle}
           </div>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image"
 import Link from "next/link"
-import { inter } from "@/lib/fonts"
+import { outfit } from "@/lib/fonts"
 
 interface ProjectProps {
   title: string
@@ -28,7 +28,7 @@ const ProjectCard = ({ title, description, imgSrc, href, github, techStack }: Pr
     )}
     <div className="p-6 md:p-8">
       <div className="flex justify-between items-start mb-4">
-        <h2 className={`text-2xl font-bold leading-8 tracking-tight text-gray-900 dark:text-gray-100 ${inter.className}`}>
+        <h2 className={`text-2xl font-bold leading-8 tracking-tight text-gray-900 dark:text-gray-100 ${outfit.className}`}>
           {href ? (
             <Link href={href} aria-label={`Link to ${title}`} className="hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
               {title}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from "next-themes"
 import { useEffect, useState } from "react"
-import { inter } from "@/lib/fonts"
+import { outfit } from "@/lib/fonts"
 
 export default function ThemeToggle() {
   const [mounted, setMounted] = useState(false)
@@ -18,7 +18,7 @@ export default function ThemeToggle() {
   if (!mounted) {
     return (
       <button
-        className={`p-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors ${inter.className}`}
+        className={`p-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors ${outfit.className}`}
         aria-label="Toggle theme"
       >
         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -36,7 +36,7 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={handleToggle}
-      className={`group relative p-2 rounded-lg bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-800 dark:to-gray-900 text-gray-700 dark:text-gray-300 hover:from-gray-200 hover:to-gray-300 dark:hover:from-gray-700 dark:hover:to-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm hover:shadow-md transition-all duration-300 hover:scale-105 ${inter.className}`}
+      className={`group relative p-2 rounded-lg bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-800 dark:to-gray-900 text-gray-700 dark:text-gray-300 hover:from-gray-200 hover:to-gray-300 dark:hover:from-gray-700 dark:hover:to-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm hover:shadow-md transition-all duration-300 hover:scale-105 ${outfit.className}`}
       aria-label={`Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode`}
     >
       <div className="relative w-5 h-5">

--- a/components/notionblocks/BlockQuote.tsx
+++ b/components/notionblocks/BlockQuote.tsx
@@ -2,43 +2,19 @@ import { SpanText } from "@/components/notionblocks/CommonBlocks"
 
 export const BlockQuote = ({ value, id }) => {
   return (
-    <div className="my-4 w-full">
-      <div className="group relative overflow-hidden rounded-xl border border-gray-200/60 dark:border-gray-700/60 bg-gradient-to-br from-slate-50 via-blue-50/30 to-purple-50/20 dark:from-gray-800 dark:via-gray-800/80 dark:to-gray-700/40 p-4 shadow-md transition-all duration-500 hover:shadow-lg hover:scale-[1.001]">
-        {/* Subtle gradient overlay */}
-        <div className="absolute inset-0 bg-gradient-to-r from-blue-500/5 via-purple-500/5 to-pink-500/5 dark:from-blue-400/10 dark:via-purple-400/10 dark:to-pink-400/10 opacity-0 transition-opacity duration-500 group-hover:opacity-100"></div>
-
-        {/* Decorative border accent */}
-        <div className="absolute left-0 top-0 h-full w-0.5 bg-gradient-to-b from-blue-500 via-purple-500 to-pink-500 dark:from-blue-400 dark:via-purple-400 dark:to-pink-400 rounded-r-full"></div>
-
-        <blockquote className="relative">
-          {/* Enhanced quote icon */}
-          <div className="absolute -left-0.5 -top-0.5 flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-blue-100 to-purple-100 dark:from-blue-900/50 dark:to-purple-900/50 shadow-sm">
-            <svg className="h-4 w-4 text-blue-600/80 dark:text-blue-400/80" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M14.017 21v-7.391c0-5.704 3.731-9.57 8.983-10.609l.995 2.151c-2.432.917-3.995 3.638-3.995 5.849h4v10h-9.983zm-14.017 0v-7.391c0-5.704 3.748-9.57 9-10.609l.996 2.151c-2.433.917-3.996 3.638-3.996 5.849h4v10h-10z" />
-            </svg>
-          </div>
-
-          <div className="relative pl-10">
-            <div className="space-y-2">
-              <p className="text-lg leading-relaxed text-gray-800 dark:text-gray-200 font-medium transition-colors">
-                <SpanText text={value.rich_text} id={id + "_span"} />
-              </p>
-
-              {/* Subtle bottom accent */}
-              <div className="flex justify-end">
-                <div className="h-0.5 w-12 bg-gradient-to-r from-blue-400 to-purple-400 dark:from-blue-500 dark:to-purple-500 rounded-full opacity-60"></div>
-              </div>
-            </div>
-          </div>
-        </blockquote>
-
-        {/* Decorative elements */}
-        <div className="absolute bottom-2 right-2 opacity-10 dark:opacity-20">
-          <svg className="h-6 w-6 text-gray-400 dark:text-gray-500" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M9.983 3v7.391c0 5.704-3.731 9.57-8.983 10.609l-.995-2.151c2.432-.917 3.995-3.638 3.995-5.849h-4v-10h9.983zm14.017 0v7.391c0 5.704-3.748 9.57-9 10.609l-.996-2.151c2.433-.917 3.996-3.638 3.996-5.849h-4v-10h10z" />
+    <div className="my-8 w-full">
+      <blockquote className="relative border-l-4 border-blue-500 dark:border-blue-400 bg-gray-50 dark:bg-gray-800/50 pl-6 pr-4 py-4 rounded-r-lg transition-colors">
+        {/* Quote icon */}
+        <div className="absolute -left-3 top-3 flex h-6 w-6 items-center justify-center rounded-full bg-blue-500 dark:bg-blue-400 shadow-sm">
+          <svg className="h-3.5 w-3.5 text-white" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M14.017 21v-7.391c0-5.704 3.731-9.57 8.983-10.609l.995 2.151c-2.432.917-3.995 3.638-3.995 5.849h4v10h-9.983zm-14.017 0v-7.391c0-5.704 3.748-9.57 9-10.609l.996 2.151c-2.433.917-3.996 3.638-3.996 5.849h4v10h-10z" />
           </svg>
         </div>
-      </div>
+
+        <div className="leading-7 text-gray-700 dark:text-gray-300 italic text-base">
+          <SpanText text={value.rich_text} id={id + "_span"} />
+        </div>
+      </blockquote>
     </div>
   )
 }

--- a/components/notionblocks/Bookmark.tsx
+++ b/components/notionblocks/Bookmark.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import OptimizedImage from "../OptimizedImage"
-import { inter } from "@/lib/fonts"
+import { outfit } from "@/lib/fonts"
 
 export const Bookmark = ({ id, value }) => {
   // Fetch the bookmark preview image using the url meta
@@ -69,7 +69,7 @@ const showBookmark = (value, id, previewTitle, previewDesp, previewImage, hasErr
   return (
     <a href={value.url} target="_blank" rel="noreferrer" className="block w-full" id={id}>
       <div
-        className={`flex flex-col sm:flex-row overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm dark:shadow-gray-900/20 transition-all duration-200 hover:shadow-md dark:hover:shadow-gray-900/40 hover:border-gray-300 dark:hover:border-gray-600 ${hasImage ? "h-auto sm:h-24 md:h-28" : "h-auto"} ${inter.className}`}
+        className={`flex flex-col sm:flex-row overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm dark:shadow-gray-900/20 transition-all duration-200 hover:shadow-md dark:hover:shadow-gray-900/40 hover:border-gray-300 dark:hover:border-gray-600 ${hasImage ? "h-auto sm:h-24 md:h-28" : "h-auto"} ${outfit.className}`}
       >
         {/* Content section */}
         <div className={`flex flex-col justify-between p-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/50 ${hasImage ? "w-full sm:w-3/5" : "w-full"} min-h-[80px] sm:min-h-0`}>
@@ -135,7 +135,7 @@ const showBookmark = (value, id, previewTitle, previewDesp, previewImage, hasErr
 const showBookmarkSkeleton = (id) => {
   return (
     <div className="block w-full" id={id}>
-      <div className={`flex flex-col sm:flex-row overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 h-auto sm:h-24 md:h-28 transition-colors ${inter.className}`}>
+      <div className={`flex flex-col sm:flex-row overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 h-auto sm:h-24 md:h-28 transition-colors ${outfit.className}`}>
         {/* Content skeleton */}
         <div className="flex w-full sm:w-3/5 animate-pulse flex-col justify-between p-3 min-h-[80px] sm:min-h-0">
           <div className="flex-1 space-y-2">

--- a/components/notionblocks/Callout.tsx
+++ b/components/notionblocks/Callout.tsx
@@ -75,11 +75,11 @@ export const Callout = ({ id, value, children }) => {
   const style = getCalloutStyle(value.color)
 
   return (
-    <div className={`my-2 w-full flex rounded-md border ${style.border} ${style.bg} p-4 shadow-sm transition-colors duration-200`}>
-      <div className={`mr-4 flex size-8 shrink-0 items-center justify-center rounded-full ${style.iconBg} text-lg transition-colors duration-200`}>{icon}</div>
-      <div className={`flex-1 min-w-0 ${style.text} leading-relaxed transition-colors duration-200`}>
+    <div className={`my-8 w-full flex rounded-md border ${style.border} ${style.bg} p-3 shadow-sm transition-colors duration-200`}>
+      <div className={`mr-3 flex size-7 shrink-0 items-center justify-center rounded-full ${style.iconBg} text-base transition-colors duration-200`}>{icon}</div>
+      <div className={`flex-1 min-w-0 ${style.text} leading-7 text-base transition-colors duration-200`}>
         <SpanText text={value.rich_text} id={id} />
-        {children && <div className="mt-2 text-sm">{children}</div>}
+        {children && <div className="mt-1.5">{children}</div>}
       </div>
     </div>
   )

--- a/components/notionblocks/Code.tsx
+++ b/components/notionblocks/Code.tsx
@@ -146,7 +146,7 @@ export const Code = ({ value }) => {
   }
 
   return (
-    <div className="my-6 w-full">
+    <div className="my-4 w-full">
       <div className="mx-auto max-w-5xl">
         <div className="group relative overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950 shadow-2xl dark:shadow-gray-900/50 transition-all duration-500 hover:shadow-3xl hover:scale-[1.005] code-block-glow">
           {/* Animated gradient border */}
@@ -154,7 +154,7 @@ export const Code = ({ value }) => {
 
           {/* Language label with icon */}
           {language && language !== "text" && (
-            <div className="relative border-b border-gray-700/50 bg-gradient-to-r from-gray-800 to-gray-750 px-3 md:px-6 py-2">
+            <div className="relative border-b border-gray-700/50 bg-gradient-to-r from-gray-800 to-gray-750 px-2 md:px-4 py-2">
               <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-2 md:space-x-3">
                   <div className="flex space-x-1">
@@ -210,13 +210,13 @@ export const Code = ({ value }) => {
             {/* Additional inner glow */}
             <div className="absolute inset-0 bg-gradient-to-r from-transparent via-blue-500/2 to-transparent pointer-events-none"></div>
 
-            <pre className="relative overflow-x-auto p-3 md:p-6 text-xs md:text-sm leading-6 md:leading-7 scrollbar-thin scrollbar-track-gray-800 scrollbar-thumb-gray-600 hover:scrollbar-thumb-gray-500 bg-transparent">
+            <pre className="relative overflow-x-auto p-2 md:p-4 text-sm leading-6 md:leading-7 scrollbar-thin scrollbar-track-gray-800 scrollbar-thumb-gray-600 hover:scrollbar-thumb-gray-500 bg-transparent">
               <code
                 ref={codeBlock}
                 className={`${code_class} block whitespace-pre text-gray-100 bg-transparent font-mono ${jetbrainsMono.className}`}
                 style={{
                   background: "transparent !important",
-                  fontSize: "0.8rem",
+                  fontSize: "0.875rem",
                   lineHeight: "1.6",
                 }}
               >

--- a/components/notionblocks/CommonBlocks.tsx
+++ b/components/notionblocks/CommonBlocks.tsx
@@ -1,22 +1,22 @@
-import { inter, jetbrainsMono } from "@/lib/fonts"
+import { outfit, jetbrainsMono } from "@/lib/fonts"
 
 export const Heading = ({ text, level, id }) => {
   switch (level) {
     case "heading_1":
       return (
-        <h1 className={`mb-6 mt-8 text-2xl md:text-3xl lg:text-4xl xl:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 font-sans transition-colors ${inter.className}`}>
+        <h1 className={`mb-4 mt-5 text-xl md:text-2xl lg:text-3xl xl:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 font-sans transition-colors ${outfit.className}`}>
           <SpanText text={text} id={id} />
         </h1>
       )
     case "heading_2":
       return (
-        <h2 className={`mb-4 mt-8 text-xl md:text-2xl lg:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100 font-sans transition-colors ${inter.className}`}>
+        <h2 className={`mb-3 mt-5 text-lg md:text-xl lg:text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100 font-sans transition-colors ${outfit.className}`}>
           <SpanText text={text} id={id} />
         </h2>
       )
     case "heading_3":
       return (
-        <h3 className={`mb-3 mt-6 text-lg md:text-xl lg:text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100 font-sans transition-colors ${inter.className}`}>
+        <h3 className={`mb-2 mt-4 text-base md:text-lg lg:text-xl font-semibold tracking-tight text-gray-900 dark:text-gray-100 font-sans transition-colors ${outfit.className}`}>
           <SpanText text={text} id={id} />
         </h3>
       )
@@ -74,7 +74,7 @@ export const ListItem = ({ value, id, clazz = null }) => {
 
 export const Text = ({ text, id }) => {
   return (
-    <p className="mb-6 leading-8 text-gray-700 dark:text-gray-300 text-lg transition-colors">
+    <p className="mb-4 leading-7 text-gray-700 dark:text-gray-300 text-base transition-colors">
       <SpanText text={text} id={id} />
     </p>
   )

--- a/components/notionblocks/Image.tsx
+++ b/components/notionblocks/Image.tsx
@@ -44,7 +44,7 @@ export const NotionImage: React.FC<NotionImageProps> = ({ id, value }) => {
 
   if (!imageSrc) {
     return (
-      <div className="my-4 w-full">
+      <div className="my-8 w-full">
         <div className="mx-auto max-w-4xl rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 p-8 text-center transition-colors">
           <p className="text-gray-500 dark:text-gray-400 transition-colors">Image not available</p>
         </div>
@@ -54,7 +54,7 @@ export const NotionImage: React.FC<NotionImageProps> = ({ id, value }) => {
 
   return (
     <>
-      <figure key={id} className="my-4 w-full">
+      <figure key={id} className="my-8 w-full">
         <div className="relative mx-auto w-full max-w-4xl overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm dark:shadow-gray-900/20 transition-colors">
           <button
             type="button"
@@ -84,7 +84,7 @@ export const NotionImage: React.FC<NotionImageProps> = ({ id, value }) => {
             </div>
           </button>
         </div>
-        {caption && <figcaption className="mx-auto mt-4 max-w-4xl text-center text-sm leading-relaxed text-gray-600 dark:text-gray-400 transition-colors">{caption}</figcaption>}
+        {caption && <figcaption className="mx-auto mt-3 max-w-4xl text-center text-sm leading-normal text-gray-600 dark:text-gray-400 transition-colors">{caption}</figcaption>}
       </figure>
 
       {zoomedImage && <ImageZoomModal src={zoomedImage.src} alt={zoomedImage.alt} onClose={() => setZoomedImage(null)} />}

--- a/components/notionblocks/Lists.tsx
+++ b/components/notionblocks/Lists.tsx
@@ -9,7 +9,7 @@ export const NumberedList = (blocks, index, parentId) => {
   }
   index--
   const output = (
-    <ol className="my-4 list-outside list-decimal space-y-1 pl-6 leading-relaxed text-gray-900 dark:text-gray-100 transition-colors" key={parentId}>
+    <ol className="my-3 list-outside list-decimal space-y-1 pl-6 leading-normal text-gray-900 dark:text-gray-100 transition-colors text-base" key={parentId}>
       {numberedList}
     </ol>
   )
@@ -28,7 +28,7 @@ export const BulletedList = (blocks, index, parentId) => {
   }
   index--
   const output = (
-    <ul className="my-4 list-outside list-disc space-y-1 pl-6 leading-relaxed text-gray-900 dark:text-gray-100 transition-colors" key={parentId}>
+    <ul className="my-3 list-outside list-disc space-y-1 pl-6 leading-normal text-gray-900 dark:text-gray-100 transition-colors text-base" key={parentId}>
       {bulletedList}
     </ul>
   )

--- a/layouts/BlogLayout.tsx
+++ b/layouts/BlogLayout.tsx
@@ -1,5 +1,5 @@
 import Container from "@/components/Container"
-import { merriweather } from "@/lib/fonts"
+import { manrope } from "@/lib/fonts"
 
 export default function BlogLayout({ children, data }) {
   const postImage = data.properties.cover
@@ -13,7 +13,7 @@ export default function BlogLayout({ children, data }) {
       type="article"
       image={postImageUrl}
     >
-      <article className={`mx-auto mb-16 flex w-full max-w-3xl px-4 md:px-0 flex-col items-start justify-center font-serif ${merriweather.className}`}>{children}</article>
+      <article className={`mx-auto mb-12 flex w-full max-w-3xl px-4 md:px-0 flex-col items-start justify-center font-serif ${manrope.className}`}>{children}</article>
     </Container>
   )
 }

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,24 +1,24 @@
-import { Inter } from "next/font/google"
-import { Merriweather } from "next/font/google"
+import { Outfit } from "next/font/google"
+import { Manrope } from "next/font/google"
 import { JetBrains_Mono } from "next/font/google"
 import { NextFont } from "next/dist/compiled/@next/font"
 
 // Primary font for UI elements, navigation, and general content
-export const inter: NextFont = Inter({
+export const outfit: NextFont = Outfit({
   subsets: ["latin"],
   weight: ["300", "400", "500", "600", "700"],
   display: "swap",
   preload: true,
-  variable: "--font-inter",
+  variable: "--font-outfit",
 })
 
 // Secondary font for blog content and reading experience
-export const merriweather: NextFont = Merriweather({
+export const manrope: NextFont = Manrope({
   subsets: ["latin"],
-  weight: ["300", "400", "700"],
+  weight: ["300", "400", "500", "600", "700"],
   display: "swap",
   preload: true,
-  variable: "--font-merriweather",
+  variable: "--font-manrope",
 })
 
 // Monospace font for code blocks and technical content

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,5 @@
 import "../styles/globals.css"
-import { inter } from "@/lib/fonts"
+import { outfit } from "@/lib/fonts"
 import { AppProps } from "next/app"
 import Head from "next/head"
 import PerformanceMonitor from "@/components/PerformanceMonitor"
@@ -22,7 +22,7 @@ function App({ Component, pageProps }: AppProps) {
       </Head>
       <PerformanceMonitor />
       <div className="min-h-screen bg-white dark:bg-gray-900 transition-colors">
-        <main className={`${inter.className} font-sans`}>
+        <main className={`${outfit.className} font-sans`}>
           <Component {...pageProps} />
         </main>
       </div>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,5 +1,5 @@
 import Container from "@/components/Container"
-import { inter } from "@/lib/fonts"
+import { outfit } from "@/lib/fonts"
 
 const About = () => {
   return (
@@ -7,7 +7,7 @@ const About = () => {
       <div className="mx-auto mb-16 px-4 max-w-3xl">
         <div className="mb-24 text-center">
           <h1
-            className={`mx-auto mb-4 w-full text-4xl font-bold tracking-tight text-black dark:text-white md:text-6xl lg:text-7xl font-sans transition-colors ${inter.className}`}
+            className={`mx-auto mb-4 w-full text-4xl font-bold tracking-tight text-black dark:text-white md:text-6xl lg:text-7xl font-sans transition-colors ${outfit.className}`}
           >
             About Me
           </h1>
@@ -26,7 +26,7 @@ const About = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222" />
               </svg>
             </div>
-            <h2 className={`text-3xl font-bold text-gray-900 dark:text-white ${inter.className}`}>Education</h2>
+            <h2 className={`text-3xl font-bold text-gray-900 dark:text-white ${outfit.className}`}>Education</h2>
           </div>
           <div className="bg-gray-50 dark:bg-gray-800/50 rounded-2xl p-8 hover:shadow-lg transition-all duration-300 border border-gray-100 dark:border-gray-700">
             <div className="flex flex-col md:flex-row md:items-center justify-between mb-4">
@@ -46,7 +46,7 @@ const About = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
               </svg>
             </div>
-            <h2 className={`text-3xl font-bold text-gray-900 dark:text-white ${inter.className}`}>Experience</h2>
+            <h2 className={`text-3xl font-bold text-gray-900 dark:text-white ${outfit.className}`}>Experience</h2>
           </div>
 
           <div className="space-y-8">
@@ -101,7 +101,7 @@ const About = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
               </svg>
             </div>
-            <h2 className={`text-3xl font-bold text-gray-900 dark:text-white ${inter.className}`}>Skills</h2>
+            <h2 className={`text-3xl font-bold text-gray-900 dark:text-white ${outfit.className}`}>Skills</h2>
           </div>
           <div className="bg-white dark:bg-black rounded-2xl border border-gray-200 dark:border-gray-800 p-6">
             <div className="space-y-6">
@@ -162,7 +162,7 @@ const About = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z" />
               </svg>
             </div>
-            <h2 className={`text-3xl font-bold text-gray-900 dark:text-white ${inter.className}`}>Publications</h2>
+            <h2 className={`text-3xl font-bold text-gray-900 dark:text-white ${outfit.className}`}>Publications</h2>
           </div>
           <div className="bg-gradient-to-br from-pink-50 to-orange-50 dark:from-pink-900/10 dark:to-orange-900/10 rounded-2xl p-8 border border-pink-100 dark:border-pink-900/30">
             <ul className="space-y-4">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 
 import { getAllPublishedBlogPosts } from "@/lib/notion"
 import { siteMetadata } from "@/lib/siteMetadata"
-import { inter } from "@/lib/fonts"
+import { outfit } from "@/lib/fonts"
 
 export const getStaticProps = async () => {
   const posts = await getAllPublishedBlogPosts(process.env.NOTION_BLOG_DATABASE_ID)
@@ -21,13 +21,13 @@ export default function Home({ posts }: InferGetStaticPropsType<typeof getStatic
     <Container>
       <div className="mx-auto mb-16 px-4 max-w-3xl">
         <div className="mb-24 text-center">
-          <h1 className={`mx-auto mb-4 w-full text-4xl font-bold tracking-tight text-black dark:text-white md:text-6xl lg:text-7xl font-sans transition-colors ${inter.className}`}>
+          <h1 className={`mx-auto mb-4 w-full text-4xl font-bold tracking-tight text-black dark:text-white md:text-6xl lg:text-7xl font-sans transition-colors ${outfit.className}`}>
             {siteMetadata.headerTitle}
           </h1>
           <p className="mx-auto max-w-2xl text-gray-600 dark:text-gray-400 text-lg md:text-xl leading-relaxed transition-colors">{siteMetadata.description}</p>
         </div>
 
-        <h2 className={`mb-10 text-2xl font-bold tracking-tight text-black dark:text-white md:text-3xl font-sans transition-colors ${inter.className}`}>Latest Writing</h2>
+        <h2 className={`mb-10 text-2xl font-bold tracking-tight text-black dark:text-white md:text-3xl font-sans transition-colors ${outfit.className}`}>Latest Writing</h2>
 
         {!posts.length && <p className="mb-4 text-gray-600 dark:text-gray-400 transition-colors">No posts found.</p>}
 
@@ -37,7 +37,7 @@ export default function Home({ posts }: InferGetStaticPropsType<typeof getStatic
               <article key={post.id} className="flex flex-col space-y-3">
                 <Link href={`/posts/${post.slug}`}>
                   <h3
-                    className={`text-2xl font-bold leading-8 tracking-tight text-gray-900 dark:text-gray-100 font-sans transition-colors hover:text-teal-600 dark:hover:text-teal-400 ${inter.className}`}
+                    className={`text-2xl font-bold leading-8 tracking-tight text-gray-900 dark:text-gray-100 font-sans transition-colors hover:text-teal-600 dark:hover:text-teal-400 ${outfit.className}`}
                   >
                     {post.title}
                   </h3>

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -2,7 +2,7 @@ import Link from "next/link"
 import BlogLayout from "@/layouts/BlogLayout"
 import { getNotionPageWithBlocks, getNotionBlockChildren, getAllPublishedBlogPosts } from "@/lib/notion"
 import { RenderBlocks } from "@/components/ContentBlocks"
-import { inter } from "@/lib/fonts"
+import { outfit } from "@/lib/fonts"
 
 const databaseId = process.env.NOTION_BLOG_DATABASE_ID
 
@@ -27,22 +27,22 @@ export default function Post({ page, blocks }) {
   return (
     <BlogLayout data={page}>
       {/* Back Link */}
-      <div className="w-full max-w-3xl mx-auto mb-8">
-        <Link href="/" className={`text-sm text-gray-500 hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400 transition-colors ${inter.className}`}>
+      <div className="w-full max-w-4xl mx-auto mb-8">
+        <Link href="/" className={`text-sm text-gray-500 hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400 transition-colors ${outfit.className}`}>
           ← Back to Blog
         </Link>
       </div>
 
       {/* Header */}
-      <div className="w-full max-w-3xl mx-auto text-center mb-12 border-b border-gray-200 dark:border-gray-800 pb-12">
-        <div className={`mb-4 text-sm font-medium text-gray-500 dark:text-gray-400 ${inter.className}`}>{date}</div>
+      <div className="w-full max-w-4xl mx-auto text-center mb-4 md:mb-8">
+        <div className={`mb-3 text-sm font-medium text-gray-500 dark:text-gray-400 ${outfit.className}`}>{date}</div>
 
-        <h1 className={`mb-6 text-3xl md:text-5xl font-bold tracking-tight text-gray-900 dark:text-gray-100 ${inter.className}`}>{title}</h1>
+        <h1 className={`mb-4 text-2xl md:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 ${outfit.className}`}>{title}</h1>
 
         {tags.length > 0 && (
           <div className="flex flex-wrap justify-center gap-2">
             {tags.map((tag) => (
-              <span key={tag.id} className={`px-3 py-1 text-xs font-medium rounded-full bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 uppercase tracking-wider ${inter.className}`}>
+              <span key={tag.id} className={`px-3 py-1 text-xs font-medium rounded-full bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 uppercase tracking-wider ${outfit.className}`}>
                 {tag.name}
               </span>
             ))}
@@ -51,7 +51,7 @@ export default function Post({ page, blocks }) {
       </div>
 
       {/* Content */}
-      <div className="w-full max-w-3xl mx-auto prose dark:prose-invert">
+      <div className="w-full max-w-4xl mx-auto prose dark:prose-invert">
         <RenderBlocks blocks={blocks} />
       </div>
     </BlogLayout>

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -1,7 +1,7 @@
 import Container from "@/components/Container"
 import ProjectCard from "@/components/ProjectCard"
 import projectsData from "@/data/projectsData"
-import { inter } from "@/lib/fonts"
+import { outfit } from "@/lib/fonts"
 
 export default function Projects() {
   return (
@@ -9,7 +9,7 @@ export default function Projects() {
       <div className="mx-auto mb-16 px-4 max-w-3xl">
         <div className="mb-12 text-center">
           <h1
-            className={`mx-auto mb-4 w-full text-4xl font-bold tracking-tight text-black dark:text-white md:text-6xl lg:text-7xl font-sans transition-colors ${inter.className}`}
+            className={`mx-auto mb-4 w-full text-4xl font-bold tracking-tight text-black dark:text-white md:text-6xl lg:text-7xl font-sans transition-colors ${outfit.className}`}
           >
             Projects
           </h1>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -49,28 +49,28 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  line-height: 1.5; /* Tighter default for UI */
+  line-height: 1.4; /* Tighter default for UI */
 }
 
 /* Mobile-friendly paragraph spacing */
 p {
-  margin-bottom: 1rem;
-  line-height: 1.6;
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
 }
 
 @media (min-width: 768px) {
   p {
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
+    line-height: 1.5;
+    margin-bottom: 1rem;
   }
 }
 
-/* 
-  Reading Mode Typography 
+/*
+  Reading Mode Typography
   Scientific Optimization:
-  - Size: 1.25rem (20px) for ideal readability at arm's length.
-  - Line-height: 1.7 (approx 160-180% is golden zone).
-  - Font: Merriweather (Serif) for flow.
+  - Size: Optimized for readability
+  - Line-height: Comfortable for long-form reading
+  - Font: Manrope (Geometric) for modern design
 */
 .prose {
     font-size: 1rem; /* Mobile base */
@@ -86,9 +86,9 @@ p {
 .prose p,
 .prose ul,
 .prose ol {
-  font-family: var(--font-merriweather);
-  line-height: 1.75;
-  margin-bottom: 1.5em; /* Breathing room */
+  font-family: var(--font-manrope);
+  line-height: 1.7;
+  margin-bottom: 1em; /* Breathing room */
   color: var(--color-gray-800);
 }
 
@@ -103,11 +103,11 @@ p {
 .prose h2,
 .prose h3,
 .prose h4 {
-    font-family: var(--font-inter); /* Contrast with body */
+    font-family: var(--font-outfit); /* Contrast with body */
     font-weight: 700;
-    margin-top: 2em;
-    margin-bottom: 0.8em;
-    line-height: 1.3;
+    margin-top: 1.5em;
+    margin-bottom: 0.6em;
+    line-height: 1.25;
 }
 
 /* Custom scrollbar styles for code blocks */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,8 +9,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        'sans': ['var(--font-inter)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-        'serif': ['var(--font-merriweather)', 'ui-serif', 'Georgia', 'serif'],
+        'sans': ['var(--font-outfit)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        'serif': ['var(--font-manrope)', 'ui-serif', 'Georgia', 'serif'],
         'mono': ['var(--font-jetbrains-mono)', 'ui-monospace', 'SFMono-Regular', 'monospace'],
       },
     },


### PR DESCRIPTION
This pull request introduces a new `CLAUDE.md` guidance file for Claude Code, and makes several minor UI and cache-related updates. The main focus is on improving project documentation, standardizing spacing in rendered Notion blocks for a more consistent look, and updating cache metadata for Notion content.

**Key changes include:**

### Documentation and Developer Guidance

* Added a comprehensive `CLAUDE.md` file that explains project architecture, commands, caching strategies, Notion integration, and development patterns. This will help new contributors and AI tools understand and work with the codebase more effectively.

### UI Consistency Improvements

* Adjusted vertical spacing (margin and padding) for various Notion block types in `components/ContentBlocks.tsx` to ensure a more visually consistent and compact layout, including dividers, figures, bookmarks, tables, todos, and toggle blocks. [[1]](diffhunk://#diff-96dcdad06ba2cfe55400af498455c5b7d9e0cffd6b8a1f53e506c6dea1101816L44-R44) [[2]](diffhunk://#diff-96dcdad06ba2cfe55400af498455c5b7d9e0cffd6b8a1f53e506c6dea1101816L90-R94) [[3]](diffhunk://#diff-96dcdad06ba2cfe55400af498455c5b7d9e0cffd6b8a1f53e506c6dea1101816L110-R110) [[4]](diffhunk://#diff-96dcdad06ba2cfe55400af498455c5b7d9e0cffd6b8a1f53e506c6dea1101816L126-R126) [[5]](diffhunk://#diff-96dcdad06ba2cfe55400af498455c5b7d9e0cffd6b8a1f53e506c6dea1101816L147-R147) [[6]](diffhunk://#diff-96dcdad06ba2cfe55400af498455c5b7d9e0cffd6b8a1f53e506c6dea1101816L158-R160)

* Changed the font import in `components/Footer.tsx` from `inter` to `outfit` for improved typographic consistency.

### Notion Cache Updates

* Updated cache metadata and timestamps in `.notion-cache/blocks-index.json`, `.notion-cache/index.json`, and Notion page cache files to reflect the latest content and ensure cache coherence. [[1]](diffhunk://#diff-a5686902da7b419b4da68c0744bf12305a27c2fc6f0074d59b2fefc651c7d651L13-R13) [[2]](diffhunk://#diff-a5686902da7b419b4da68c0744bf12305a27c2fc6f0074d59b2fefc651c7d651L28-R48) [[3]](diffhunk://#diff-a5686902da7b419b4da68c0744bf12305a27c2fc6f0074d59b2fefc651c7d651L63-R63) [[4]](diffhunk://#diff-a5686902da7b419b4da68c0744bf12305a27c2fc6f0074d59b2fefc651c7d651R86-R105) [[5]](diffhunk://#diff-dbb1ca19aa6c4aec89d6bb3feb2d083d0c89d05223f7379bb15a93acb6885543L4-R12) [[6]](diffhunk://#diff-dbb1ca19aa6c4aec89d6bb3feb2d083d0c89d05223f7379bb15a93acb6885543L44-R44) [[7]](diffhunk://#diff-dbb1ca19aa6c4aec89d6bb3feb2d083d0c89d05223f7379bb15a93acb6885543L76-R80) [[8]](diffhunk://#diff-b430dea1915f7dee226a26d767ab6864224c910f848bc0b28d5443068f5326f0L183-R183) [[9]](diffhunk://#diff-b430dea1915f7dee226a26d767ab6864224c910f848bc0b28d5443068f5326f0L2521-R2521) [[10]](diffhunk://#diff-79c96ca16f27b00557cd72ad6b7fb6fcedb0a88ce41384cb8e4ce89ac876b85aL183-R183) [[11]](diffhunk://#diff-79c96ca16f27b00557cd72ad6b7fb6fcedb0a88ce41384cb8e4ce89ac876b85aL6972-R6972) [[12]](diffhunk://#diff-5c60e30afea716b48795099821295ab9d60d21e4db34aececcca87594ad6079fL180-R180) [[13]](diffhunk://#diff-5c60e30afea716b48795099821295ab9d60d21e4db34aececcca87594ad6079fL2496-R2496) [[14]](diffhunk://#diff-64490cea7b9440d95ad6b2182f567cf9c524348e990e351888259eba7ded13dcL180-R180) [[15]](diffhunk://#diff-64490cea7b9440d95ad6b2182f567cf9c524348e990e351888259eba7ded13dcL2565-R2565) [[16]](diffhunk://#diff-9c15cc75ed4fc14eb40f427bb1f2bbdba46cbb37d2ce980a35420a564a48417cL183-R183) [[17]](diffhunk://#diff-9c15cc75ed4fc14eb40f427bb1f2bbdba46cbb37d2ce980a35420a564a48417cL4013-R4013) [[18]](diffhunk://#diff-5f4a7f3524f69012f9dd1885557d74d86216acdc013a04aa4551332e4a639c75L183-R183) [[19]](diffhunk://#diff-5f4a7f3524f69012f9dd1885557d74d86216acdc013a04aa4551332e4a639c75L4055-R4055)